### PR TITLE
Add Laravel 12 support and release v1.0.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,10 +17,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2 ]
-        laravel: [ 11.*]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 12.*, 11.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `laravel-ollama` will be documented in this file.
 
+## v1.0.0 - 2026-02-25
+
+### What's Changed
+
+- Added Laravel 12 support
+- Added PHP 8.4 support
+- Updated CI workflow to test against Laravel 12, 11 with PHP 8.4, 8.3, 8.2
+- Updated dev dependencies for broader version compatibility (Pest 3, PHPStan 2, Orchestra Testbench 10)
+
 ## v0.0.1 - 2024-05-03
 
 This is the pre-release.

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
+        "nunomaduro/collision": "^7.10.0||^8.1.1",
         "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3",
+        "orchestra/testbench": "^8.22.0||^9.0.0||^10.0",
+        "pestphp/pest": "^2.34||^3.0",
+        "pestphp/pest-plugin-arch": "^2.7||^3.0",
+        "pestphp/pest-plugin-laravel": "^2.3||^3.0",
+        "phpstan/extension-installer": "^1.3||^2.0",
+        "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
+        "phpstan/phpstan-phpunit": "^1.3||^2.0",
         "spatie/laravel-ray": "^1.35"
     },
     "autoload": {


### PR DESCRIPTION
- Add illuminate/contracts ^12.0 to supported versions
- Add PHP 8.4 to CI test matrix
- Add Laravel 12 with Orchestra Testbench 10 to CI matrix
- Widen dev dependency version constraints for Pest 3, PHPStan 2, and Orchestra Testbench 10 compatibility
- Update CHANGELOG with v1.0.0 release notes

https://claude.ai/code/session_01SLEn54sYY9LdnxxmsXba2p